### PR TITLE
翻译修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1150,8 +1150,8 @@ float FAggregatorModChannel::MultiplyMods(const TArray<FAggregatorMod>& InMods, 
 * 该`GameplayEffectSpec`的当前堆栈数. 堆栈限制取决于`GameplayEffect`.
 * [GameplayEffectContextHandle](#concepts-ge-context)表明该`GameplayEffectSpec`由谁创建.
 * 在`GameplayEffectSpec`创建时由Snapshot捕获的`Attribute`.
-* 除了`GameplayEffect`授予的`GameplayTags`, `GameplayEffectSpec`还会授予目标(Target)`DynamicGrantedTags`.
-* 除了`GameplayEffect`拥有的`AssetTags`, `GameplayEffectSpec`还会拥有`DynamicAssetTags`.
+* 在`GameplayEffect`授予的`GameplayTags`之外, `GameplayEffectSpec`额外授予目标(Target)的`DynamicGrantedTags`.
+* 在`GameplayEffect`拥有的`AssetTags`之外, `GameplayEffectSpec`额外拥有的`DynamicAssetTags`.
 * `SetByCaller TMaps`.
 
 **[⬆ 返回目录](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -1149,7 +1149,7 @@ float FAggregatorModChannel::MultiplyMods(const TArray<FAggregatorMod>& InMods, 
 * 对于周期性Effect中`GameplayEffectSpec`的周期, 默认是`GameplayEffect`的周期, 但是可以是不同的.
 * 该`GameplayEffectSpec`的当前堆栈数. 堆栈限制取决于`GameplayEffect`.
 * [GameplayEffectContextHandle](#concepts-ge-context)表明该`GameplayEffectSpec`由谁创建.
-* `Attribute`在`GameplayEffectSpec`创建时由Snapshot捕获.
+* 在`GameplayEffectSpec`创建时由Snapshot捕获的`Attribute`.
 * 除了`GameplayEffect`授予的`GameplayTags`, `GameplayEffectSpec`还会授予目标(Target)`DynamicGrantedTags`.
 * 除了`GameplayEffect`拥有的`AssetTags`, `GameplayEffectSpec`还会拥有`DynamicAssetTags`.
 * `SetByCaller TMaps`.

--- a/README.md
+++ b/README.md
@@ -906,7 +906,7 @@ virtual void OnActiveGameplayEffectAddedCallback(UAbilitySystemComponent* Target
 
 为了在`GameplayAbility`之外移除`GameplayEffect`, 你就需要获取到该目标的`ASC`并使用它的函数之一来`RemoveActiveGameplayEffect`.  
 
-你可以绑定`持续(Duration)`或`无限(Infinite)GameplayEffect`的委托来监听其应用到`ASC`:  
+你可以绑定`持续(Duration)`或`无限(Infinite)GameplayEffect`的委托来监听其从`ASC`上移除:  
 
 ```c++
 AbilitySystemComponent->OnAnyGameplayEffectRemovedDelegate().AddUObject(this, &APACharacterBase::OnRemoveGameplayEffectCallback);

--- a/README.md
+++ b/README.md
@@ -748,7 +748,7 @@ void UGDAttributeSetBase::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& 
 
 `REPTNOTIFY_Always`用于设置OnRep函数在客户端值已经与服务端同步的值相同的情况下触发(因为有预测), 默认设置下, 客户端值与服务端同步的值相同时, OnRep函数是不会触发的.  
 
-如果`Attribute`无需像`Meta Attribute`那样同步, 那么`OnRep`和`GetLifetimeReplicatedProps`步骤可以跳过.  
+如果`Attribute`像`Meta Attribute`那样无需同步, 那么`OnRep`和`GetLifetimeReplicatedProps`步骤可以跳过.  
 
 **[⬆ 返回目录](#table-of-contents)**
 


### PR DESCRIPTION
1. 原文"If the Attribute is not replicated like a Meta Attribute, then the OnRep and GetLifetimeReplicatedProps steps can be skipped."
但是4.3.3节明确提到"Meta Attributes are not typically replicated.", 即meta attribute一般不会被复制. 
所以这里的翻译应该是"如果该attribute像meta attribute一样无需同步, 那么..."

2. 一些明显的小错误和语法问题纠正